### PR TITLE
fix :: 회원가입 중복 확인 수정

### DIFF
--- a/src/app/item/[[...id]]/page.tsx
+++ b/src/app/item/[[...id]]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Header from "@/src/components/Header";
 import Footer from "@/src/components/Footer";
@@ -39,6 +39,8 @@ export default function Page() {
   const reviewCount = 24;
   const review = 4.5;
   const [isExpanded, setIsExpanded] = useState(false);
+  const [canExpand, setCanExpand] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
   const [post, setPost] = useState<Post | null>(null);
   const [relatedPosts, setRelatedPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
@@ -64,6 +66,12 @@ export default function Page() {
       .then((list) => setIsFavorited(list.some((p) => p.id === postId)))
       .catch(() => {});
   }, [token, postId]);
+
+  useEffect(() => {
+    const el = descriptionRef.current;
+    if (!el) return;
+    setCanExpand(el.scrollHeight > el.clientHeight + 1);
+  }, [post]);
 
   async function handleToggleFavorite() {
     if (!token || !postId) { router.push("/login/signin"); return; }
@@ -190,16 +198,19 @@ export default function Page() {
             <div className="flex flex-col gap-4">
               <h2 className="text-xl font-bold">서비스 설명</h2>
               <p
-                className={`${isExpanded
+                ref={descriptionRef}
+                className={`${isExpanded || !canExpand
                   ? "text-zinc-500"
                   : "line-clamp-10 bg-linear-to-b from-zinc-500 via-zinc-300 to-white bg-clip-text text-transparent"
                 }`}
               >
                 {description || "서비스 설명이 없습니다."}
               </p>
-              <DoButton onClick={() => setIsExpanded(!isExpanded)}>
-                {isExpanded ? "접기" : "더보기"}
-              </DoButton>
+              {canExpand && (
+                <DoButton onClick={() => setIsExpanded(!isExpanded)}>
+                  {isExpanded ? "접기" : "더보기"}
+                </DoButton>
+              )}
             </div>
 
             {/* 리뷰 */}

--- a/src/components/login/InputPhone.tsx
+++ b/src/components/login/InputPhone.tsx
@@ -12,6 +12,13 @@ interface InputPhoneProps {
     onNext: () => void;
 }
 
+function formatPhone(value: string): string {
+    const digits = value.replace(/\D/g, "").slice(0, 11);
+    if (digits.length <= 3) return digits;
+    if (digits.length <= 7) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+}
+
 const InputPhone = ({ formData, setFormData, onNext }: InputPhoneProps) => {
     const handleChange = (key: keyof SignUpFormData, value: string) => {
         setFormData((prev) => ({ ...prev, [key]: value }));
@@ -20,17 +27,17 @@ const InputPhone = ({ formData, setFormData, onNext }: InputPhoneProps) => {
     const [showVerification, setShowVerification] = useState(false);
     const [isWaiting, setIsWaiting] = useState(false);
 
-    const isAllValid = 
+    const isAllValid =
         formData.phone.trim() !== "" &&
-        /^010\d{8}$/.test(formData.phone) &&
+        /^010-\d{4}-\d{4}$/.test(formData.phone) &&
         (!showVerification || formData.phoneVerification.trim() !== "");
 
     const VerificationCode = "123456"; // 실제로는 서버에서 받아와야 함. 임시
 
     return (
         <div className="mt-5">
-            <InputField label="전화번호 입력" placeholder="전화번호를 입력해주세요" 
-            isEssential={true} value={formData.phone} onChange={(e) => handleChange("phone", e.target.value)} />
+            <InputField label="전화번호 입력" placeholder="전화번호를 입력해주세요"
+            isEssential={true} value={formData.phone} onChange={(e) => handleChange("phone", formatPhone(e.target.value))} />
 
             {showVerification && (
                 <InputField 

--- a/src/components/login/inputData.tsx
+++ b/src/components/login/inputData.tsx
@@ -24,11 +24,7 @@ const InputData = ({ formData, setFormData, onNext }: InputDataProps) => {
         if (!isAllValid || checking) return;
         setChecking(true);
         try {
-            const res = await checkUsername(formData.username);
-            if (!res.available) {
-                setUsernameError(res.message || "이미 사용 중인 아이디입니다.");
-                return;
-            }
+            await checkUsername(formData.username);
             onNext();
         } catch (e) {
             setUsernameError(e instanceof Error ? e.message : "아이디 확인에 실패했습니다.");

--- a/src/lib/member.ts
+++ b/src/lib/member.ts
@@ -5,37 +5,28 @@ function authHeaders(token: string) {
   }
 }
 
-// 아이디 중복 확인
+// 아이디 중복 확인 (사용 가능하면 정상 반환, 중복이면 throw)
 export async function checkUsername(username: string) {
-  const res = await fetch(`/api/member/check-username`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(username),
-  })
+  const params = new URLSearchParams({ username })
+  const res = await fetch(`/api/member/check-username?${params}`)
   const json = await res.json()
   if (!res.ok) throw new Error(json?.error?.message ?? '이미 사용 중인 아이디입니다.')
-  return json.data as { available: boolean; message: string }
+  return json.data as { message: string }
 }
 
-// 이메일 중복 확인
+// 이메일 중복 확인 (사용 가능하면 정상 반환, 중복이면 throw)
 export async function checkEmail(email: string) {
-  const res = await fetch(`/api/member/check-email`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(email),
-  })
+  const params = new URLSearchParams({ email })
+  const res = await fetch(`/api/member/check-email?${params}`)
   const json = await res.json()
   if (!res.ok) throw new Error(json?.error?.message ?? '이미 사용 중인 이메일입니다.')
   return json.data as { message: string }
 }
 
-// 전화번호 중복 확인
+// 전화번호 중복 확인 (사용 가능하면 정상 반환, 중복이면 throw)
 export async function checkPhone(phone: string) {
-  const res = await fetch(`/api/member/check-phone`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(phone),
-  })
+  const params = new URLSearchParams({ phone })
+  const res = await fetch(`/api/member/check-phone?${params}`)
   const json = await res.json()
   if (!res.ok) throw new Error(json?.error?.message ?? '이미 사용 중인 전화번호입니다.')
   return json.data as { message: string }


### PR DESCRIPTION
## 작업내용
- [x] 회원가입 아이디/이메일/전화번호 중복확인 API 연동 방식 수정 (GET + 쿼리파라미터, 새 백엔드 계약에 맞춤)
- [x] 전화번호 입력 시 3-4-4 하이픈 자동 포맷 + 11자리 제한
- [x] 아이템 페이지 서비스 설명 "더보기" 버튼이 10줄 초과일 때만 노출되도록 수정

## 관련 이슈

## 확인사항
- [x] 코드스타일이 컨벤션을 따르는지 확인하셨나요?
- [x] 모든 코드가 정상적으로 동작하는지 확인하셨나요?