### PR TITLE
fix :: 커뮤니티 삭제 버그 수정및 UI 개선

### DIFF
--- a/src/app/item/[[...id]]/page.tsx
+++ b/src/app/item/[[...id]]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Header from "@/src/components/Header";
 import Footer from "@/src/components/Footer";
@@ -39,6 +39,8 @@ export default function Page() {
   const reviewCount = 24;
   const review = 4.5;
   const [isExpanded, setIsExpanded] = useState(false);
+  const [canExpand, setCanExpand] = useState(false);
+  const descriptionRef = useRef<HTMLParagraphElement>(null);
   const [post, setPost] = useState<Post | null>(null);
   const [relatedPosts, setRelatedPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
@@ -64,6 +66,12 @@ export default function Page() {
       .then((list) => setIsFavorited(list.some((p) => p.id === postId)))
       .catch(() => {});
   }, [token, postId]);
+
+  useEffect(() => {
+    const el = descriptionRef.current;
+    if (!el) return;
+    setCanExpand(el.scrollHeight > el.clientHeight + 1);
+  }, [post]);
 
   async function handleToggleFavorite() {
     if (!token || !postId) { router.push("/login/signin"); return; }
@@ -190,16 +198,19 @@ export default function Page() {
             <div className="flex flex-col gap-4">
               <h2 className="text-xl font-bold">서비스 설명</h2>
               <p
-                className={`${isExpanded
+                ref={descriptionRef}
+                className={`${isExpanded || !canExpand
                   ? "text-zinc-500"
                   : "line-clamp-10 bg-linear-to-b from-zinc-500 via-zinc-300 to-white bg-clip-text text-transparent"
                 }`}
               >
                 {description || "서비스 설명이 없습니다."}
               </p>
-              <DoButton onClick={() => setIsExpanded(!isExpanded)}>
-                {isExpanded ? "접기" : "더보기"}
-              </DoButton>
+              {canExpand && (
+                <DoButton onClick={() => setIsExpanded(!isExpanded)}>
+                  {isExpanded ? "접기" : "더보기"}
+                </DoButton>
+              )}
             </div>
 
             {/* 리뷰 */}

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -117,7 +117,7 @@ function MainContent() {
               ? Array.from({ length: 3 }).map((_, i) => <PremiumCardSkeleton key={i} />)
               : premiumPosts.length > 0
                 ? premiumPosts.map((post) => (
-                    <PremiumCard key={post.id} id={post.id} title={post.title} content={post.content} fileUrl={post.fileUrls?.[0]} />
+                    <PremiumCard key={post.id} id={post.id} title={post.title} content={post.content} fileUrls={post.fileUrls} />
                   ))
                 : Array.from({ length: 3 }).map((_, i) => (
                     <div key={i} className="w-lg h-72 rounded-lg bg-zinc-100 flex items-center justify-center text-zinc-400 text-sm">

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -55,6 +55,12 @@ export default function Comment({ authorName, content, createdAt, profileImage, 
             <textarea
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+                  e.preventDefault()
+                  handleSave()
+                }
+              }}
               className="w-full text-sm border border-zinc-300 rounded-md p-2 focus:outline-none focus:border-main resize-none"
               rows={2}
             />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,9 @@ export default function Footer() {
           </div>
           <div className="flex gap-2">
             <FaInstagram className="text-zinc-500 w-10 h-10 border-2 border-zinc-500 rounded-lg p-1" />
-            <FaGithub className="text-zinc-500 w-10 h-10 border-2 border-zinc-500 rounded-lg p-1" />
+            <a href="https://github.com/twenty-threeD/23D-Web" target="_blank" rel="noreferrer">
+              <FaGithub className="text-zinc-500 w-10 h-10 border-2 border-zinc-500 rounded-lg p-1 hover:text-zinc-700 hover:border-zinc-700 transition-colors" />
+            </a>
           </div>
         </div>
 

--- a/src/components/PremiumCard.tsx
+++ b/src/components/PremiumCard.tsx
@@ -5,7 +5,7 @@ interface PremiumCardProps {
   id: number
   title: string
   content: string
-  fileUrl?: string
+  fileUrls?: string[]
 }
 
 function getDescription(content: string): string {
@@ -17,16 +17,24 @@ function getDescription(content: string): string {
   }
 }
 
-export default function PremiumCard({ id, title, content, fileUrl }: PremiumCardProps) {
+export default function PremiumCard({ id, title, content, fileUrls }: PremiumCardProps) {
   const description = getDescription(content)
+  const images = (fileUrls ?? []).slice(0, 2)
 
   return (
     <Link href={`/item/${id}`} className="flex flex-col w-lg h-72 p-3 rounded-lg hover:shadow-sm transition-transform duration-300">
-      <div className="w-full min-h-32 bg-zinc-300 flex items-center justify-start rounded-lg overflow-hidden">
-        {fileUrl ? (
-          <img src={toRelativeUrl(fileUrl)} alt={title} className="w-full h-full object-cover" />
-        ) : (
+      <div className="w-full h-32 bg-zinc-300 flex items-center justify-start rounded-lg overflow-hidden">
+        {images.length === 0 ? (
           <div className="w-full h-full bg-zinc-200" />
+        ) : (
+          images.map((url, i) => (
+            <img
+              key={i}
+              src={toRelativeUrl(url)}
+              alt={title}
+              className={`h-full object-cover ${images.length === 1 ? "w-full" : "w-1/2"}`}
+            />
+          ))
         )}
       </div>
       <div className="flex flex-col gap-2 py-4">

--- a/src/components/PremiumCardSkeleton.tsx
+++ b/src/components/PremiumCardSkeleton.tsx
@@ -1,7 +1,7 @@
 export default function PremiumCardSkeleton() {
   return (
     <div className="flex flex-col w-lg h-72 p-3 rounded-lg animate-pulse">
-      <div className="w-full min-h-32 bg-zinc-200 rounded-lg" />
+      <div className="w-full h-32 bg-zinc-200 rounded-lg" />
       <div className="flex flex-col gap-2 py-4">
         <div className="h-5 w-40 bg-zinc-200 rounded" />
         <div className="flex flex-col gap-1">

--- a/src/lib/community.ts
+++ b/src/lib/community.ts
@@ -58,10 +58,9 @@ export async function updatePost(
 }
 
 export async function deletePost(token: string, postId: number) {
-  const res = await fetch(`/api/community/post`, {
+  const res = await fetch(`/api/community/post?postId=${postId}`, {
     method: 'DELETE',
     headers: authHeaders(token),
-    body: JSON.stringify({ postId }),
   })
   if (!res.ok) throw new Error('게시글 삭제 실패')
   return res.json()
@@ -99,10 +98,9 @@ export async function updateComment(token: string, commentId: number, content: s
 }
 
 export async function deleteComment(token: string, commentId: number) {
-  const res = await fetch(`/api/community/comment`, {
+  const res = await fetch(`/api/community/comment?commentId=${commentId}`, {
     method: 'DELETE',
     headers: authHeaders(token),
-    body: JSON.stringify({ commentId }),
   })
   if (!res.ok) throw new Error('댓글 삭제 실패')
   return res.json()


### PR DESCRIPTION
## 작업내용
- [x] 커뮤니티 게시글 삭제가 안 되던 버그 수정 (DELETE 요청 시 postId를 body가 아닌 쿼리파라미터로 전송하도록 수정)
- [x] 커뮤니티 댓글 삭제 동일 버그 수정 (commentId 쿼리파라미터 처리)
- [x] 댓글 수정 시 Enter 키로 바로 저장되도록 개선 (Shift+Enter는 줄바꿈)
- [x] 메인 페이지 프리미엄 카드: 사진 있는/없는 카드 높이 불일치 수정, 사진 최대 2장 w-1/2 레이아웃 적용
- [x] 아이템 상세 페이지 서비스 설명 "더보기" 버튼: 10줄 초과일 때만 노출되도록 재적용
- [x] Footer GitHub 아이콘에 저장소 링크 연결

## 관련 이슈
#48 

## Jira 기능 링크(선택)


## 확인사항
- [x] 코드스타일이 컨벤션을 따르는지 확인하셨나요?
- [x] 모든 코드가 정상적으로 동작하는지 확인하셨나요?