### PR TITLE
feat :: 디자인 일관성 정리

### DIFF
--- a/src/app/chat/[[...id]]/page.tsx
+++ b/src/app/chat/[[...id]]/page.tsx
@@ -91,7 +91,6 @@ export default function Page() {
   const lastMessageOverride = useChatRoomsStore((s) => s.lastMessageOverride)
   const markRoomRead = useChatRoomsStore((s) => s.markRoomRead)
   const setActiveRoomId = useChatRoomsStore((s) => s.setActiveRoomId)
-  const selectedService = useChatRoomsStore((s) => s.selectedService)
   const clearPendingGreeting = useChatRoomsStore((s) => s.clearPendingGreeting)
   // post를 올린 사람이 을(파는 사람), 문의하기를 눌러 들어온 사람이 갑(사는 사람)이다.
   // 계정 role이 아니라 방마다 정해지므로 글 작성자를 조회해서 판단한다.
@@ -518,6 +517,20 @@ export default function Page() {
     return null
   }
 
+  // 채팅 목록 미리보기. 대괄호 접두사로 주고받는 특수 메시지는 원문 대신 짧은 문구로 보여준다
+  // (JSON 본문이 그대로 노출되거나 줄바꿈이 이어붙어 길어지는 걸 막는다).
+  function previewOf(text: string) {
+    if (!text) return ""
+    if (text.startsWith("[계약서 제안]")) return "📄 계약서를 보냈습니다."
+    if (text.startsWith("[계약서 체결 완료]")) return "✅ 계약이 체결됐습니다."
+    if (text.startsWith("[견적서 발송]")) return "🧾 견적서를 보냈습니다."
+    if (text.startsWith("[채팅 시작]")) {
+      const service = text.split("\n").find((line) => line.startsWith("선택한 서비스:"))
+      return service ?? "채팅을 시작했어요"
+    }
+    return text.replace(/\n+/g, " ")
+  }
+
   function formatTime(dateStr: string) {
     return new Date(dateStr).toLocaleString("ko-KR", {
       hour: "2-digit", minute: "2-digit",
@@ -560,7 +573,7 @@ export default function Page() {
 
       <div className="flex flex-1 px-20 pt-8 overflow-hidden">
         {/* 왼쪽 채팅 목록 */}
-        <div className="flex flex-col pr-4 shrink-0 border-r border-zinc-200">
+        <div className="flex flex-col w-80 pr-4 shrink-0 border-r border-zinc-200">
           {/* 탭 */}
           <div className="flex border-b border-zinc-200">
             {tabs.map((t) => (
@@ -600,7 +613,9 @@ export default function Page() {
             ) : (
               filteredRooms.map((room) => {
                 const isUnread = !!unreadRoomIds[room.roomId]
-                const previewText = isUnread ? "새 메시지" : (lastMessageOverride[room.roomId] ?? room.lastMessagePreview)
+                const previewText = isUnread
+                  ? "새 메시지"
+                  : previewOf(lastMessageOverride[room.roomId] ?? room.lastMessagePreview)
                 return (
                 <div
                   key={room.roomId}
@@ -694,7 +709,7 @@ export default function Page() {
                           {imageUrls.map((url) => (
                             <div
                               key={url}
-                              className="w-24 h-24 rounded-xl overflow-hidden cursor-pointer"
+                              className="w-24 h-24 rounded-xl overflow-hidden transition-opacity hover:opacity-90 cursor-pointer"
                               onClick={() => setLightboxSrc(toRelativeUrl(url))}
                             >
                               <img src={toRelativeUrl(url)} alt="첨부 이미지" className="w-full h-full object-cover" />
@@ -737,7 +752,7 @@ export default function Page() {
                   const contractReviewButton = contractMsg?.kind === "propose" && !isSent ? (
                     <button
                       onClick={() => setContractModalState({ mode: "review", initial: contractMsg.data })}
-                      className="px-4 py-2 rounded-xl bg-main text-white text-sm font-semibold hover:bg-orange-600 cursor-pointer"
+                      className="px-4 py-2 rounded-xl bg-main text-white text-sm font-semibold hover:bg-orange-600 transition-colors cursor-pointer"
                     >
                       계약서 확인하기
                     </button>
@@ -747,7 +762,7 @@ export default function Page() {
                   const payButton = contractMsg?.kind === "completed" && isSent && selectedRoom.postId ? (
                     <button
                       onClick={() => handlePayNavigate(contractMsg.data)}
-                      className="px-4 py-2 rounded-xl bg-main text-white text-sm font-semibold hover:bg-orange-600 cursor-pointer"
+                      className="px-4 py-2 rounded-xl bg-main text-white text-sm font-semibold hover:bg-orange-600 transition-colors cursor-pointer"
                     >
                       결제하기
                     </button>
@@ -813,7 +828,7 @@ export default function Page() {
                   <div className="flex flex-col items-center gap-1">
                     <button
                       onClick={() => fileInputRef.current?.click()}
-                      className="w-12 h-12 rounded-full bg-main flex items-center justify-center cursor-pointer"
+                      className="w-12 h-12 rounded-full bg-main flex items-center justify-center transition-opacity hover:opacity-85 cursor-pointer"
                     >
                       <MdOutlineImage className="text-white text-2xl" />
                     </button>
@@ -822,7 +837,7 @@ export default function Page() {
                   <div className="flex flex-col items-center gap-1">
                     <button
                       onClick={() => docInputRef.current?.click()}
-                      className="w-12 h-12 rounded-full bg-orange-300 flex items-center justify-center cursor-pointer"
+                      className="w-12 h-12 rounded-full bg-orange-300 flex items-center justify-center transition-opacity hover:opacity-85 cursor-pointer"
                     >
                       <MdOutlineDescription className="text-white text-2xl" />
                     </button>
@@ -838,11 +853,12 @@ export default function Page() {
                             initial: {
                               clientName: selectedRoom.participantName,
                               professionalName: "",
-                              price: selectedId ? selectedService[selectedId]?.price ?? "" : "",
+                              // 금액은 계약서를 쓰는 을이 직접 입력한다.
+                              // (문의 시 고른 서비스 가격은 갑의 기기에만 남아 있어 여기서는 알 수 없다)
                             },
                           })
                         }}
-                        className="w-12 h-12 rounded-full bg-yellow-400 flex items-center justify-center cursor-pointer"
+                        className="w-12 h-12 rounded-full bg-yellow-400 flex items-center justify-center transition-opacity hover:opacity-85 cursor-pointer"
                       >
                         <MdOutlineAssignment className="text-white text-2xl" />
                       </button>
@@ -853,7 +869,7 @@ export default function Page() {
                     <div className="flex flex-col items-center gap-1">
                       <button
                         onClick={() => { setShowAttach(false); setShowEstimate(true) }}
-                        className="w-12 h-12 rounded-full bg-emerald-400 flex items-center justify-center cursor-pointer"
+                        className="w-12 h-12 rounded-full bg-emerald-400 flex items-center justify-center transition-opacity hover:opacity-85 cursor-pointer"
                       >
                         <MdOutlineReceiptLong className="text-white text-2xl" />
                       </button>
@@ -875,7 +891,7 @@ export default function Page() {
                       ) : (
                         <button
                           onClick={() => clearPendingImage(i)}
-                          className="absolute top-1 right-1 w-5 h-5 bg-black/50 rounded-full flex items-center justify-center cursor-pointer"
+                          className="absolute top-1 right-1 w-5 h-5 bg-black/50 rounded-full flex items-center justify-center transition-colors hover:bg-black/70 cursor-pointer"
                         >
                           <IoClose className="text-white text-xs" />
                         </button>

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -57,7 +57,7 @@ export default function Page() {
             <Search where="post" onSearch={setKeyword} />
             <button
               onClick={() => router.push("/community/write")}
-              className="text-lg px-4 py-2 border text-center bg-main border-zinc-300 text-white font-semibold rounded-md whitespace-nowrap cursor-pointer hover:bg-orange-600"
+              className="px-4 py-2 text-center bg-main text-white text-sm font-semibold rounded-xl whitespace-nowrap transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
             >
               글작성
             </button>

--- a/src/app/community/write/[[...id]]/page.tsx
+++ b/src/app/community/write/[[...id]]/page.tsx
@@ -136,7 +136,7 @@ export default function Page() {
               <button
                 onClick={handleSubmit}
                 disabled={!isReady || submitting}
-                className="px-5 py-2 rounded-lg bg-main text-white text-sm font-semibold hover:bg-orange-600 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="px-5 py-2 rounded-xl bg-main text-white text-sm font-semibold transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
               >
                 {submitting ? (postId ? "수정 중..." : "등록 중...") : (postId ? "수정" : "등록")}
               </button>

--- a/src/app/item/[[...id]]/page.tsx
+++ b/src/app/item/[[...id]]/page.tsx
@@ -266,7 +266,7 @@ export default function Page() {
                   {post.fileUrls.map((url, i) => (
                     <div
                       key={i}
-                      className="w-48 h-48 rounded-lg overflow-hidden bg-zinc-200 cursor-pointer"
+                      className="w-48 h-48 rounded-lg overflow-hidden bg-zinc-200 transition-opacity hover:opacity-90 cursor-pointer"
                       onClick={() => setLightboxSrc(toRelativeUrl(url))}
                     >
                       <img src={toRelativeUrl(url)} alt={`이미지 ${i + 1}`} className="w-full h-full object-cover" />
@@ -316,7 +316,7 @@ export default function Page() {
                       type="button"
                       onClick={handleCreateReview}
                       disabled={reviewBusy || !reviewContent.trim()}
-                      className="rounded-lg bg-main px-4 py-2 text-sm font-semibold text-white disabled:opacity-50 cursor-pointer"
+                      className="rounded-xl bg-main px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
                     >
                       {reviewBusy ? "등록 중..." : "후기 등록"}
                     </button>

--- a/src/app/login/signin/page.tsx
+++ b/src/app/login/signin/page.tsx
@@ -110,7 +110,7 @@ export default function Page() {
             className={`w-75 h-10 rounded-lg text-lg font-bold transition-colors cursor-pointer
             ${
               canLogin
-                ? "bg-main text-white hover:bg-main/90"
+                ? "bg-main text-white hover:bg-orange-600"
                 : "bg-zinc-100 text-zinc-500 cursor-not-allowed"
             }`}
           >

--- a/src/app/login/signup/page.tsx
+++ b/src/app/login/signup/page.tsx
@@ -114,7 +114,7 @@ export default function Page() {
                                 disabled={isWaiting}
                                 onClick={handleSignup}
                                 className={`w-75 h-10 mt-12.5 rounded-lg text-lg font-bold transition-colors
-                                ${isWaiting ? 'bg-zinc-300 text-zinc-500 cursor-not-allowed' : 'bg-main text-white hover:bg-main/90'}`}
+                                ${isWaiting ? 'bg-zinc-300 text-zinc-500 cursor-not-allowed' : 'bg-main text-white hover:bg-orange-600'}`}
                             >
                                 {isWaiting ? "처리 중..." : "시작하기"}
                             </button>

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -18,7 +18,7 @@ function NoticeContent() {
       <p className="text-sm text-zinc-400">빠른 시일 내에 찾아뵙겠습니다.</p>
       <button
         onClick={() => router.back()}
-        className="mt-4 px-6 py-2 rounded-lg bg-main text-white font-semibold hover:bg-main/90 cursor-pointer"
+        className="mt-4 px-6 py-2 rounded-xl bg-main text-white text-sm font-semibold transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
       >
         돌아가기
       </button>

--- a/src/app/oauth/fail/page.tsx
+++ b/src/app/oauth/fail/page.tsx
@@ -15,7 +15,7 @@ export default function page () {
         <p className='font-medium text-zinc-400'>다시 시도해주세요</p>
         <button
           onClick={() => router.push('/login/signin')}
-          className='px-4 py-2 bg-main text-white font-bold rounded-md hover:bg-orange-600 transition-colors'
+          className='px-4 py-2 bg-main text-white text-sm font-semibold rounded-xl transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer'
         >
           다시하기
         </button>

--- a/src/app/pay/fail/page.tsx
+++ b/src/app/pay/fail/page.tsx
@@ -17,7 +17,7 @@ function FailContent() {
       <p className="text-sm text-zinc-400">{message || "결제가 취소되었거나 오류가 발생했습니다."}</p>
       <button
         onClick={() => router.replace(postId ? `/pay/${postId}` : "/main")}
-        className="mt-4 px-6 py-2 rounded-lg bg-main text-white font-semibold hover:bg-main/90 cursor-pointer"
+        className="mt-4 px-6 py-2 rounded-xl bg-main text-white text-sm font-semibold transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
       >
         돌아가기
       </button>

--- a/src/app/posts/[[...id]]/page.tsx
+++ b/src/app/posts/[[...id]]/page.tsx
@@ -351,7 +351,7 @@ export default function Page() {
                   <button
                     onClick={handleCommentSubmit}
                     disabled={submitting || !token}
-                    className="self-end px-4 py-2 bg-main text-white font-semibold rounded-lg hover:bg-orange-600 disabled:opacity-50"
+                    className="self-end px-4 py-2 bg-main text-white text-sm font-semibold rounded-xl transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
                   >
                     {submitting ? "등록 중..." : "등록"}
                   </button>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -271,7 +271,7 @@ export default function Page() {
                 <input
                   value={usernameInput}
                   onChange={(e) => setUsernameInput(e.target.value)}
-                  className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main"
+                  className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
                 />
               </div>
 
@@ -282,7 +282,7 @@ export default function Page() {
                   onChange={(e) => setShortDescription(e.target.value.slice(0, 100))}
                   maxLength={100}
                   rows={3}
-                  className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main resize-none"
+                  className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500 resize-none"
                 />
                 <span className="text-xs text-zinc-400 self-end">{shortDescription.length} / 100</span>
               </div>
@@ -292,7 +292,7 @@ export default function Page() {
                 <select
                   value={jobCategoryId}
                   onChange={(e) => setJobCategoryId(e.target.value ? Number(e.target.value) : "")}
-                  className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main"
+                  className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
                 >
                   <option value="">선택 안 함</option>
                   {jobCategories.map((c) => (
@@ -307,7 +307,7 @@ export default function Page() {
                   <select
                     value={ctprvnCd}
                     onChange={(e) => { setCtprvnCd(e.target.value); setSigCd(""); }}
-                    className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main"
+                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
                   >
                     <option value="">선택</option>
                     {sidoList.map((s) => (
@@ -321,7 +321,7 @@ export default function Page() {
                     value={sigCd}
                     onChange={(e) => setSigCd(e.target.value)}
                     disabled={!ctprvnCd}
-                    className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main disabled:bg-zinc-100"
+                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
                   >
                     <option value="">선택</option>
                     {sigunguList.map((s) => (
@@ -336,7 +336,7 @@ export default function Page() {
                 <select
                   value={movableDistance}
                   onChange={(e) => setMovableDistance(e.target.value as typeof movableDistance)}
-                  className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main"
+                  className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
                 >
                   <option value="">선택 안 함</option>
                   {DISTANCE_OPTIONS.map((o) => (
@@ -355,7 +355,7 @@ export default function Page() {
                 <button
                   onClick={handleSave}
                   disabled={saving}
-                  className="px-4 py-2 rounded-lg bg-main text-white text-sm font-semibold hover:bg-main/90 disabled:opacity-50 cursor-pointer"
+                  className="px-4 py-2 rounded-xl bg-main text-white text-sm font-semibold transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
                 >
                   {saving ? "저장 중..." : "저장"}
                 </button>
@@ -391,7 +391,7 @@ export default function Page() {
                   ) : (
                     <button
                       onClick={() => setVerifyingPhone(true)}
-                      className="text-xs text-white bg-main rounded-full px-2 py-0.5 hover:bg-main/90 transition-colors cursor-pointer"
+                      className="text-xs text-white bg-main rounded-full px-2 py-0.5 hover:bg-orange-600 transition-colors cursor-pointer"
                     >
                       인증하기
                     </button>
@@ -426,14 +426,14 @@ export default function Page() {
                   <div className="flex gap-2 px-3">
                     <button
                       onClick={() => router.push(`/upload/${p.id}`)}
-                      className="flex-1 py-1.5 rounded-md border border-zinc-300 text-xs font-semibold text-zinc-600 hover:border-main hover:text-main transition-colors cursor-pointer"
+                      className="flex-1 py-1.5 rounded-lg border border-zinc-300 text-xs font-semibold text-zinc-600 hover:border-main hover:text-main transition-colors cursor-pointer"
                     >
                       수정
                     </button>
                     <button
                       onClick={() => handleDeletePost(p.id)}
                       disabled={deletingId === p.id}
-                      className="flex-1 py-1.5 rounded-md border border-zinc-300 text-xs font-semibold text-red-500 hover:border-red-400 transition-colors disabled:opacity-50 cursor-pointer"
+                      className="flex-1 py-1.5 rounded-lg border border-zinc-300 text-xs font-semibold text-red-500 hover:border-red-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
                     >
                       {deletingId === p.id ? "삭제 중..." : "삭제"}
                     </button>

--- a/src/app/upload/[[...id]]/page.tsx
+++ b/src/app/upload/[[...id]]/page.tsx
@@ -153,7 +153,7 @@ export default function Page() {
           <button
             onClick={isWaiting ? undefined : handleSubmit}
             disabled={isWaiting}
-            className="w-32 h-10 bg-main text-white rounded-lg font-bold self-end disabled:opacity-50 cursor-pointer"
+            className="w-32 h-10 bg-main text-white text-sm rounded-xl font-semibold self-end transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
           >
             {isWaiting ? "등록 중..." : "등록하기"}
           </button>

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -61,7 +61,7 @@ export default function Comment({ authorName, content, createdAt, profileImage, 
                   handleSave()
                 }
               }}
-              className="w-full text-sm border border-zinc-300 rounded-md p-2 focus:outline-none focus:border-main resize-none"
+              className="w-full border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500 resize-none"
               rows={2}
             />
             <div className="flex gap-2 self-end">

--- a/src/components/DoButton.tsx
+++ b/src/components/DoButton.tsx
@@ -7,7 +7,7 @@ export default function DoButton({ children, onClick }: DoButtonProps) {
   return (
     <button 
       onClick={onClick} 
-      className="w-full py-2 border text-center border-zinc-300 rounded-md"
+      className="w-full py-2 border text-center text-sm font-semibold text-zinc-600 border-zinc-300 rounded-lg transition-colors hover:border-main hover:text-main cursor-pointer"
     >
       {children}
     </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -178,7 +178,7 @@ export default function Header() {
           <div ref={menuRef} className="relative">
             <button
               onClick={() => setShowMenu((v) => !v)}
-              className="w-9 h-9 rounded-full overflow-hidden border border-zinc-300 cursor-pointer"
+              className="w-9 h-9 rounded-full overflow-hidden border border-zinc-300 transition-colors hover:border-main cursor-pointer"
             >
               <Image
                 src={profileImageUrl ? toRelativeUrl(profileImageUrl) : "/profile.png"}

--- a/src/components/PriceCard.tsx
+++ b/src/components/PriceCard.tsx
@@ -99,7 +99,7 @@ export default function PriceCard({ username, plans, postId }: PriceCardProps) {
         <button
           onClick={() => setShowPicker(true)}
           disabled={loading || !username}
-          className="w-full py-2 border text-center bg-main border-zinc-300 text-white font-semibold rounded-md disabled:opacity-50 cursor-pointer"
+          className="w-full py-3 text-center bg-main text-white text-sm font-semibold rounded-xl transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
         >
           {loading ? "연결 중..." : "문의하기"}
         </button>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -36,7 +36,7 @@ export default function Search({ isTop, where, initialValue = "", onSearch }: Se
   return (
     <div className={styleClass}>
       <IoIosSearch
-        className="text-zinc-500 text-2xl cursor-pointer"
+        className="text-zinc-500 hover:text-main text-2xl transition-colors cursor-pointer"
         onClick={() => onSearch?.(value)}
       />
       <input

--- a/src/components/chat/ContractWizardModal.tsx
+++ b/src/components/chat/ContractWizardModal.tsx
@@ -1,9 +1,12 @@
 "use client"
 
 import { useState } from "react"
-import { IoClose, IoCheckmark } from "react-icons/io5"
+import { IoCheckmark } from "react-icons/io5"
 import SignaturePad from "./SignaturePad"
 import { buildContractPdf } from "@/src/lib/contractPdf"
+import Modal from "@/src/components/ui/Modal"
+import Button from "@/src/components/ui/Button"
+import { inputClass, inputShellClass } from "@/src/components/ui/Field"
 
 export interface ContractData {
   clientName: string
@@ -62,7 +65,7 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
   const [endDate, setEndDate] = useState(initial.endDate ?? "")
   const [inspectionDays, setInspectionDays] = useState(initial.inspectionDays ?? "")
   const [serviceContent, setServiceContent] = useState(initial.serviceContent ?? "")
-  const [price] = useState(initial.price ?? "")
+  const [price, setPrice] = useState(initial.price ?? "")
   const [clientSig, setClientSig] = useState(initial.clientSig ?? "")
   const [professionalSig, setProfessionalSig] = useState(initial.professionalSig ?? "")
   const [generatingPdf, setGeneratingPdf] = useState(false)
@@ -76,7 +79,12 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
   const step1Valid =
     clientName.trim() !== "" &&
     professionalName.trim() !== "" &&
-    (!termsEditable || (startDate !== "" && endDate !== "" && inspectionDays.trim() !== "" && serviceContent.trim() !== ""))
+    (!termsEditable ||
+      (startDate !== "" &&
+        endDate !== "" &&
+        inspectionDays.trim() !== "" &&
+        serviceContent.trim() !== "" &&
+        Number(price.replace(/[^0-9]/g, "")) > 0))
 
   const mySig = myRole === "client" ? clientSig : professionalSig
   // review는 갑이 마지막으로 서명하는 단계라, 제출하려면 양쪽 서명이 다 있어야 한다(=바로 서버에 등록되므로).
@@ -127,19 +135,13 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
   const showSignatures = step === 2
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-modal-backdrop">
-      <div className="bg-white w-full max-w-5xl max-h-[90vh] rounded-2xl shadow-2xl mx-4 flex flex-col overflow-hidden animate-modal-panel">
-        <div className="flex items-center justify-between px-8 py-5 border-b border-zinc-200 shrink-0">
-          <span className="text-lg font-bold">계약서 {mode === "propose" ? "작성" : "검토 및 서명"}</span>
-          <button
-            onClick={onClose}
-            className="w-9 h-9 rounded-full flex items-center justify-center text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer"
-          >
-            <IoClose className="text-2xl" />
-          </button>
-        </div>
-
-        <div className="flex flex-1 overflow-hidden">
+    <Modal
+      title={`계약서 ${mode === "propose" ? "작성" : "검토 및 서명"}`}
+      width="lg"
+      closeOnBackdrop={false}
+      bare
+      onClose={onClose}
+    >
           {/* 계약서 미리보기 */}
           <div className="flex-1 overflow-y-auto px-10 py-8 border-r border-zinc-200 bg-zinc-50/60">
             <div className="max-w-2xl mx-auto bg-white rounded-xl shadow-sm ring-1 ring-zinc-100 px-10 py-10 flex flex-col gap-6">
@@ -208,7 +210,7 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                     onChange={(e) => setClientName(e.target.value)}
                     disabled={!canEditClientName}
                     placeholder="갑 성명"
-                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-main hover:border-zinc-400 transition-colors disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+                    className={inputClass}
                   />
                 </label>
                 <label className="flex flex-col gap-1 text-sm">
@@ -218,7 +220,7 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                     onChange={(e) => setProfessionalName(e.target.value)}
                     disabled={!canEditProfessionalName}
                     placeholder="을 성명"
-                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-main hover:border-zinc-400 transition-colors disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+                    className={inputClass}
                   />
                 </label>
                 <label className="flex flex-col gap-1 text-sm">
@@ -228,7 +230,7 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                     value={startDate}
                     onChange={(e) => setStartDate(e.target.value)}
                     disabled={!termsEditable}
-                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-main hover:border-zinc-400 transition-colors disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+                    className={inputClass}
                   />
                 </label>
                 <label className="flex flex-col gap-1 text-sm">
@@ -238,12 +240,12 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                     value={endDate}
                     onChange={(e) => setEndDate(e.target.value)}
                     disabled={!termsEditable}
-                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-main hover:border-zinc-400 transition-colors disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+                    className={inputClass}
                   />
                 </label>
                 <label className="flex flex-col gap-1 text-sm">
                   검수 일수
-                  <div className="flex items-center border border-zinc-300 rounded-lg px-3 py-2.5 gap-1 focus-within:border-main hover:border-zinc-400 transition-colors">
+                  <div className={inputShellClass}>
                     <input
                       type="number"
                       min={0}
@@ -257,6 +259,21 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                   </div>
                 </label>
                 <label className="flex flex-col gap-1 text-sm">
+                  계약 금액
+                  <div className={inputShellClass}>
+                    <input
+                      type="number"
+                      min={0}
+                      value={price}
+                      onChange={(e) => setPrice(e.target.value)}
+                      disabled={!termsEditable}
+                      placeholder="계약 금액"
+                      className="flex-1 text-sm focus:outline-none disabled:bg-transparent disabled:text-zinc-500"
+                    />
+                    <span className="text-sm text-zinc-400">원</span>
+                  </div>
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
                   1조 내용 (용역 내용)
                   <textarea
                     value={serviceContent}
@@ -264,17 +281,13 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                     disabled={!termsEditable}
                     rows={3}
                     placeholder="어떤 용역을 수행하는지 적어주세요"
-                    className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-main hover:border-zinc-400 transition-colors resize-none disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+                    className={`${inputClass} resize-none`}
                   />
                 </label>
 
-                <button
-                  disabled={!step1Valid}
-                  onClick={() => setStep(2)}
-                  className="w-full py-3 rounded-xl text-white font-semibold text-sm bg-main hover:bg-orange-600 transition-colors disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
-                >
+                <Button size="lg" disabled={!step1Valid} onClick={() => setStep(2)}>
                   다음
-                </button>
+                </Button>
               </div>
             ) : (
               <div className="flex flex-col gap-4">
@@ -298,18 +311,12 @@ export default function ContractWizardModal({ myRole, mode, initial, busy, phone
                   이전으로
                 </button>
 
-                <button
-                  disabled={!canSubmit || busy || generatingPdf}
-                  onClick={handleSubmit}
-                  className="w-full py-3 rounded-xl text-white font-semibold text-sm bg-main hover:bg-orange-600 transition-colors disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer"
-                >
+                <Button size="lg" disabled={!canSubmit || busy || generatingPdf} onClick={handleSubmit}>
                   {generatingPdf ? "PDF 생성 중..." : busy ? (isReview ? "등록 중..." : "전송 중...") : mode === "propose" ? "제안하기" : "서명하고 계약서 등록"}
-                </button>
+                </Button>
               </div>
             )}
           </div>
-        </div>
-      </div>
-    </div>
+    </Modal>
   )
 }

--- a/src/components/chat/EstimateModal.tsx
+++ b/src/components/chat/EstimateModal.tsx
@@ -1,8 +1,11 @@
 "use client"
 
 import { useState } from "react"
-import { IoClose, IoDocumentTextOutline, IoCloudUploadOutline, IoCheckmarkCircle } from "react-icons/io5"
+import { IoCloudUploadOutline, IoCheckmarkCircle } from "react-icons/io5"
 import { uploadFile } from "@/src/lib/file"
+import Modal, { ModalActions } from "@/src/components/ui/Modal"
+import Button from "@/src/components/ui/Button"
+import Field, { inputShellClass } from "@/src/components/ui/Field"
 
 interface EstimateModalProps {
   token: string
@@ -34,84 +37,50 @@ export default function EstimateModal({ token, totalPay, busy, onClose, onSubmit
   }
 
   return (
-    <div
-      className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50 animate-modal-backdrop"
-      onClick={onClose}
-    >
-      <div
-        className="bg-white rounded-2xl shadow-2xl w-100 p-6 flex flex-col gap-5 animate-modal-panel"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="w-9 h-9 rounded-full bg-emerald-100 flex items-center justify-center shrink-0">
-              <IoDocumentTextOutline className="text-emerald-500 text-lg" />
-            </span>
-            <h2 className="text-lg font-bold">견적서 보내기</h2>
-          </div>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 rounded-full flex items-center justify-center text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer"
-          >
-            <IoClose className="text-xl" />
-          </button>
+    <Modal title="견적서 보내기" width="md" onClose={onClose}>
+      <Field label="견적 금액">
+        <div className={inputShellClass}>
+          <input
+            type="number"
+            min={1}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0"
+            className="flex-1 text-sm focus:outline-none"
+          />
+          <span className="text-sm text-zinc-400">원</span>
         </div>
+      </Field>
 
-        <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium text-zinc-600">견적 금액</label>
-          <div className="flex items-center gap-2 border border-zinc-300 rounded-xl px-3 py-2.5 focus-within:border-main transition-colors">
-            <input
-              type="number"
-              min={1}
-              value={amount}
-              onChange={(e) => setAmount(e.target.value)}
-              placeholder="0"
-              className="flex-1 text-sm focus:outline-none"
-            />
-            <span className="text-sm text-zinc-400">원</span>
-          </div>
-        </div>
+      <Field label="견적서 파일">
+        <label
+          className={`flex flex-col items-center gap-2 border border-dashed rounded-lg px-3 py-6 text-sm text-center cursor-pointer transition-colors ${
+            fileName ? "border-main bg-main/5" : "border-zinc-300 hover:border-main hover:bg-main/5"
+          }`}
+        >
+          <input type="file" className="hidden" onChange={handleFile} disabled={uploading} />
+          {uploading ? (
+            <span className="text-zinc-400">업로드 중...</span>
+          ) : fileName ? (
+            <>
+              <IoCheckmarkCircle className="text-2xl text-main" />
+              <span className="text-zinc-700 font-medium truncate max-w-full">{fileName}</span>
+            </>
+          ) : (
+            <>
+              <IoCloudUploadOutline className="text-2xl text-zinc-400" />
+              <span className="text-zinc-500">클릭해서 파일 선택</span>
+            </>
+          )}
+        </label>
+      </Field>
 
-        <div className="flex flex-col gap-1.5">
-          <label className="text-sm font-medium text-zinc-600">견적서 파일</label>
-          <label
-            className={`flex flex-col items-center gap-2 border border-dashed rounded-xl px-3 py-6 text-sm text-center cursor-pointer transition-colors ${
-              fileName ? "border-main bg-main/5" : "border-zinc-300 hover:border-main hover:bg-main/5"
-            }`}
-          >
-            <input type="file" className="hidden" onChange={handleFile} disabled={uploading} />
-            {uploading ? (
-              <span className="text-zinc-400">업로드 중...</span>
-            ) : fileName ? (
-              <>
-                <IoCheckmarkCircle className="text-2xl text-main" />
-                <span className="text-zinc-700 font-medium truncate max-w-full">{fileName}</span>
-              </>
-            ) : (
-              <>
-                <IoCloudUploadOutline className="text-2xl text-zinc-400" />
-                <span className="text-zinc-500">클릭해서 파일 선택</span>
-              </>
-            )}
-          </label>
-        </div>
-
-        <div className="flex gap-2 justify-end pt-1">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 rounded-xl text-sm text-zinc-500 hover:bg-zinc-100 transition-colors cursor-pointer"
-          >
-            취소
-          </button>
-          <button
-            onClick={() => onSubmit({ url, totalPay: Number(amount) })}
-            disabled={!canSubmit}
-            className="px-5 py-2 rounded-xl bg-main text-white text-sm font-semibold hover:bg-orange-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
-          >
-            {busy ? "전송 중..." : "보내기"}
-          </button>
-        </div>
-      </div>
-    </div>
+      <ModalActions>
+        <Button variant="ghost" onClick={onClose}>취소</Button>
+        <Button onClick={() => onSubmit({ url, totalPay: Number(amount) })} disabled={!canSubmit}>
+          {busy ? "전송 중..." : "보내기"}
+        </Button>
+      </ModalActions>
+    </Modal>
   )
 }

--- a/src/components/chat/SignaturePad.tsx
+++ b/src/components/chat/SignaturePad.tsx
@@ -103,13 +103,13 @@ export default function SignaturePad({ label, onSave, savedUrl }: SignaturePadPr
           <div className="flex gap-2">
             <button
               onClick={handleClear}
-              className="flex-1 py-1.5 text-xs border border-zinc-300 rounded-md text-zinc-500 cursor-pointer hover:bg-zinc-50 transition-colors"
+              className="flex-1 py-1.5 text-xs font-semibold border border-zinc-300 rounded-lg text-zinc-600 cursor-pointer hover:border-main hover:text-main transition-colors"
             >
               지우기
             </button>
             <button
               onClick={handleSave}
-              className="flex-1 py-1.5 text-xs bg-main text-white rounded-md cursor-pointer hover:bg-orange-600 transition-colors"
+              className="flex-1 py-1.5 text-xs bg-main text-white font-semibold rounded-lg transition-colors hover:bg-orange-600 cursor-pointer"
             >
               서명 확인
             </button>

--- a/src/components/item/ServicePickerModal.tsx
+++ b/src/components/item/ServicePickerModal.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { IoClose, IoChevronForward, IoEllipsisHorizontal } from "react-icons/io5"
+import { IoChevronForward, IoEllipsisHorizontal } from "react-icons/io5"
 import { type PriceCardPlan } from "@/src/types/priceCard"
+import Modal from "@/src/components/ui/Modal"
 
 interface ServicePickerModalProps {
   plans: PriceCardPlan[]
@@ -12,57 +13,40 @@ interface ServicePickerModalProps {
 
 export default function ServicePickerModal({ plans, busy, onClose, onSelect }: ServicePickerModalProps) {
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-modal-backdrop"
-      onClick={onClose}
-    >
-      <div
-        className="bg-white w-full max-w-sm rounded-2xl shadow-2xl p-6 flex flex-col gap-4 mx-4 animate-modal-panel"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-bold">어떤 서비스가 궁금하세요?</h2>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 rounded-full flex items-center justify-center text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer"
-          >
-            <IoClose className="text-xl" />
-          </button>
-        </div>
-        <p className="text-sm text-zinc-500">문의하실 서비스를 선택해주세요.</p>
+    <Modal title="어떤 서비스가 궁금하세요?" width="sm" onClose={onClose}>
+      <p className="text-sm text-zinc-500">문의하실 서비스를 선택해주세요.</p>
 
-        <div className="flex flex-col gap-2">
-          {plans.map((plan, i) => (
-            <button
-              key={i}
-              disabled={busy}
-              onClick={() => onSelect({ planName: plan.planName || `플랜 ${i + 1}`, price: plan.price })}
-              className="group flex items-center justify-between gap-3 w-full px-4 py-3.5 border border-zinc-200 rounded-xl hover:border-main hover:bg-main/5 hover:shadow-sm transition-all text-left cursor-pointer disabled:opacity-50"
-            >
-              <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="font-semibold text-sm truncate">{plan.planName || `플랜 ${i + 1}`}</span>
-                {plan.price && (
-                  <span className="text-xs text-zinc-500">
-                    {Number(plan.price.replace(/,/g, "")).toLocaleString()}원~
-                  </span>
-                )}
-              </div>
-              <IoChevronForward className="text-zinc-300 group-hover:text-main shrink-0 transition-colors" />
-            </button>
-          ))}
+      <div className="flex flex-col gap-2">
+        {plans.map((plan, i) => (
           <button
+            key={i}
             disabled={busy}
-            onClick={() => onSelect({ planName: "기타", price: "" })}
-            className="group flex items-center justify-between gap-3 w-full px-4 py-3.5 border border-dashed border-zinc-300 rounded-xl hover:border-main hover:bg-main/5 transition-all text-left cursor-pointer disabled:opacity-50"
+            onClick={() => onSelect({ planName: plan.planName || `플랜 ${i + 1}`, price: plan.price })}
+            className="group flex items-center justify-between gap-3 w-full px-4 py-3.5 border border-zinc-300 rounded-lg hover:border-main hover:bg-main/5 transition-colors text-left cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            <span className="flex items-center gap-2 text-sm font-semibold text-zinc-600">
-              <IoEllipsisHorizontal className="text-base" />
-              기타
-            </span>
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <span className="font-semibold text-sm truncate">{plan.planName || `플랜 ${i + 1}`}</span>
+              {plan.price && (
+                <span className="text-xs text-zinc-500">
+                  {Number(plan.price.replace(/,/g, "")).toLocaleString()}원~
+                </span>
+              )}
+            </div>
             <IoChevronForward className="text-zinc-300 group-hover:text-main shrink-0 transition-colors" />
           </button>
-        </div>
+        ))}
+        <button
+          disabled={busy}
+          onClick={() => onSelect({ planName: "기타", price: "" })}
+          className="group flex items-center justify-between gap-3 w-full px-4 py-3.5 border border-dashed border-zinc-300 rounded-lg hover:border-main hover:bg-main/5 transition-colors text-left cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <span className="flex items-center gap-2 text-sm font-semibold text-zinc-600">
+            <IoEllipsisHorizontal className="text-base" />
+            기타
+          </span>
+          <IoChevronForward className="text-zinc-300 group-hover:text-main shrink-0 transition-colors" />
+        </button>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/src/components/login/InputEmail.tsx
+++ b/src/components/login/InputEmail.tsx
@@ -72,7 +72,7 @@ const InputEmail = ({ formData, setFormData, onNext }: InputEmailProps) => {
                 onClick={() => { showVerification ? handleVerify() : handleSendCode() }}
                 className={`w-75 h-10 mt-10 rounded-lg text-lg font-bold transition-colors cursor-pointer
                 ${isAllValid && !isWaiting
-                    ? 'bg-main text-white hover:bg-main/90'
+                    ? 'bg-main text-white hover:bg-orange-600'
                     : 'bg-zinc-300 text-zinc-500 cursor-not-allowed'}`}
             >
                 {isWaiting ? "처리 중..." : showVerification ? "다음" : "인증번호 발송"}

--- a/src/components/login/InputPhone.tsx
+++ b/src/components/login/InputPhone.tsx
@@ -104,7 +104,7 @@ const InputPhone = ({ formData, setFormData, onNext }: InputPhoneProps) => {
                 onClick={handleSubmit}
                 className={`w-75 h-10 mt-12.5 rounded-lg text-lg font-bold transition-colors
                 ${isAllValid && !isWaiting
-                    ? 'bg-main text-white hover:bg-main/90 cursor-pointer'
+                    ? 'bg-main text-white hover:bg-orange-600 cursor-pointer'
                     : 'bg-zinc-300 text-zinc-500 cursor-not-allowed'}`}
             >
                 {isWaiting ? "처리 중..." : showVerification ? "인증 확인" : "인증번호 발송"}

--- a/src/components/login/inputData.tsx
+++ b/src/components/login/inputData.tsx
@@ -104,7 +104,7 @@ const InputData = ({ formData, setFormData, onNext }: InputDataProps) => {
                 onClick={handleNext}
                 className={`w-75 mt-10 h-10 rounded-lg text-lg font-bold transition-colors
                 ${isAllValid && !checking
-                    ? 'bg-main text-white hover:bg-main/90'
+                    ? 'bg-main text-white hover:bg-orange-600'
                     : 'bg-zinc-300 text-zinc-500 cursor-not-allowed'}`}
             >
                 다음

--- a/src/components/pay/OnClickPay.tsx
+++ b/src/components/pay/OnClickPay.tsx
@@ -108,9 +108,9 @@ export const OnClickPay = ({ isAgree, price, orderName, orderCustomerName, postI
       <button
         onClick={handlePayment}
         disabled={!isAgree}
-        className={`w-87.5 mt-5 py-3 rounded-lg text-lg font-bold transition-colors
+        className={`w-87.5 mt-5 py-3 rounded-xl text-lg font-bold transition-colors
           ${isAgree
-            ? "bg-main text-white hover:bg-main/90 cursor-pointer"
+            ? "bg-main text-white hover:bg-orange-600 cursor-pointer"
             : "bg-zinc-300 text-zinc-500 cursor-not-allowed"
           }`}
       >

--- a/src/components/profile/AccountEditModal.tsx
+++ b/src/components/profile/AccountEditModal.tsx
@@ -5,11 +5,14 @@ import { sendEmailChangeCode, sendPhoneVerifyCode, checkPhoneVerifyCode, verifyP
 import { changeEmail, changePhone } from "@/src/lib/member";
 import { useToast } from "@/src/hooks/useToast";
 import { useHandleError } from "@/src/hooks/useHandleError";
+import Modal, { ModalActions } from "@/src/components/ui/Modal";
+import Button from "@/src/components/ui/Button";
+import Field, { inputClass } from "@/src/components/ui/Field";
 
-type Field = "email" | "phone";
+type AccountField = "email" | "phone";
 
 interface AccountEditModalProps {
-  field: Field;
+  field: AccountField;
   token: string;
   /** 번호 변경 없이 기존 번호를 인증만 할 때 사용한다 */
   verifyOnlyPhone?: string;
@@ -106,96 +109,76 @@ export default function AccountEditModal({ field, token, verifyOnlyPhone, onClos
   const title = isVerifyOnly ? "전화번호 인증" : `${label} 변경`;
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl w-100 p-6 flex flex-col gap-4">
-        <h2 className="text-lg font-bold">{title}</h2>
-
-        {step === "password" ? (
-          <>
-            <p className="text-sm text-zinc-500">
-              본인 확인을 위해 현재 비밀번호를 입력해주세요.
-            </p>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleCheckPassword(); }}
-              placeholder="현재 비밀번호"
-              autoFocus
-              className="border border-zinc-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-main"
-            />
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 rounded-lg text-sm text-zinc-500 hover:bg-zinc-100 cursor-pointer"
+    <Modal title={title} width="md" closeOnBackdrop={false} onClose={onClose}>
+      {step === "password" ? (
+        <>
+          <p className="text-sm text-zinc-500">
+            본인 확인을 위해 현재 비밀번호를 입력해주세요.
+          </p>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") handleCheckPassword(); }}
+            placeholder="현재 비밀번호"
+            autoFocus
+            className={inputClass}
+          />
+          <ModalActions>
+            <Button variant="ghost" onClick={onClose}>취소</Button>
+            <Button
+              onClick={handleCheckPassword}
+              disabled={password === "" || checkingPassword}
+            >
+              {checkingPassword ? "확인 중..." : "다음"}
+            </Button>
+          </ModalActions>
+        </>
+      ) : (
+        <>
+          <Field label={isVerifyOnly ? "전화번호" : `새 ${label}`}>
+            <div className="flex gap-2">
+              <input
+                type={isEmail ? "email" : "tel"}
+                value={value}
+                onChange={(e) => setValue(isEmail ? e.target.value : formatPhone(e.target.value))}
+                placeholder={isEmail ? "new@example.com" : "010-0000-0000"}
+                disabled={isVerifyOnly}
+                className={`flex-1 ${inputClass}`}
+              />
+              <Button
+                variant="secondary"
+                onClick={handleSendCode}
+                disabled={!isValueValid || sending}
+                className="whitespace-nowrap"
               >
-                취소
-              </button>
-              <button
-                onClick={handleCheckPassword}
-                disabled={password === "" || checkingPassword}
-                className="px-4 py-2 rounded-lg bg-main text-white text-sm font-semibold disabled:opacity-50 cursor-pointer"
-              >
-                {checkingPassword ? "확인 중..." : "다음"}
-              </button>
+                {sending ? "발송 중..." : codeSent ? "재발송" : "인증번호"}
+              </Button>
             </div>
-          </>
-        ) : (
-          <>
-            <div className="flex flex-col gap-1">
-              <label className="text-sm text-zinc-500">
-                {isVerifyOnly ? "전화번호" : `새 ${label}`}
-              </label>
-              <div className="flex gap-2">
-                <input
-                  type={isEmail ? "email" : "tel"}
-                  value={value}
-                  onChange={(e) => setValue(isEmail ? e.target.value : formatPhone(e.target.value))}
-                  placeholder={isEmail ? "new@example.com" : "010-0000-0000"}
-                  disabled={isVerifyOnly}
-                  className="flex-1 border border-zinc-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-main disabled:bg-zinc-100 disabled:text-zinc-500"
-                />
-                <button
-                  onClick={handleSendCode}
-                  disabled={!isValueValid || sending}
-                  className="px-3 rounded-lg border border-zinc-300 text-sm font-semibold text-zinc-600 hover:border-main hover:text-main transition-colors disabled:opacity-50 cursor-pointer whitespace-nowrap"
-                >
-                  {sending ? "발송 중..." : codeSent ? "재발송" : "인증번호"}
-                </button>
-              </div>
-            </div>
+          </Field>
 
-            {codeSent && (
-              <div className="flex flex-col gap-1">
-                <label className="text-sm text-zinc-500">인증번호</label>
-                <input
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  placeholder="인증번호를 입력해주세요"
-                  autoFocus
-                  className="border border-zinc-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-main"
-                />
-              </div>
-            )}
+          {codeSent && (
+            <Field label="인증번호">
+              <input
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="인증번호를 입력해주세요"
+                autoFocus
+                className={inputClass}
+              />
+            </Field>
+          )}
 
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={isVerifyOnly ? onClose : () => setStep("password")}
-                className="px-4 py-2 rounded-lg text-sm text-zinc-500 hover:bg-zinc-100 cursor-pointer"
-              >
-                {isVerifyOnly ? "취소" : "이전"}
-              </button>
-              <button
-                onClick={handleSubmit}
-                disabled={!canSubmit || saving}
-                className="px-4 py-2 rounded-lg bg-main text-white text-sm font-semibold disabled:opacity-50 cursor-pointer"
-              >
-                {saving ? "처리 중..." : isVerifyOnly ? "인증" : "변경"}
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
+          <ModalActions>
+            <Button variant="ghost" onClick={isVerifyOnly ? onClose : () => setStep("password")}>
+              {isVerifyOnly ? "취소" : "이전"}
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit || saving}>
+              {saving ? "처리 중..." : isVerifyOnly ? "인증" : "변경"}
+            </Button>
+          </ModalActions>
+        </>
+      )}
+    </Modal>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+type Variant = "primary" | "secondary" | "ghost"
+type Size = "sm" | "md" | "lg"
+
+const VARIANT_CLASS: Record<Variant, string> = {
+  primary: "bg-main text-white hover:bg-orange-600 disabled:hover:bg-main",
+  secondary:
+    "border border-zinc-300 text-zinc-600 hover:border-main hover:text-main disabled:hover:border-zinc-300 disabled:hover:text-zinc-600",
+  ghost: "text-zinc-500 hover:bg-zinc-100",
+}
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "w-full py-3 text-sm",
+}
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant
+  size?: Size
+}
+
+export default function Button({
+  variant = "primary",
+  size = "md",
+  className = "",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      className={`rounded-xl font-semibold transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed ${VARIANT_CLASS[variant]} ${SIZE_CLASS[size]} ${className}`}
+    />
+  )
+}

--- a/src/components/ui/Field.tsx
+++ b/src/components/ui/Field.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+// 폼 입력의 테두리·여백·포커스 스타일을 한곳에서 관리한다.
+export const inputClass =
+  "border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors " +
+  "focus:outline-none focus:border-main hover:border-zinc-400 " +
+  "disabled:bg-zinc-100 disabled:text-zinc-500 disabled:hover:border-zinc-300"
+
+// 인풋 안에 버튼·단위 같은 걸 같이 넣을 때 쓰는 껍데기 (인풋 자체는 border 없이)
+export const inputShellClass =
+  "flex items-center gap-1 border border-zinc-300 rounded-lg px-3 py-2.5 transition-colors " +
+  "focus-within:border-main hover:border-zinc-400"
+
+interface FieldProps {
+  label: string
+  children: React.ReactNode
+}
+
+export default function Field({ label, children }: FieldProps) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium text-zinc-600">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useEffect } from "react"
+import { IoClose } from "react-icons/io5"
+
+type ModalWidth = "sm" | "md" | "lg"
+
+const WIDTH_CLASS: Record<ModalWidth, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-5xl",
+}
+
+interface ModalProps {
+  title: string
+  width?: ModalWidth
+  /** 배경 클릭으로 닫히지 않게 하려면 false (작성 중 내용이 날아가면 안 되는 모달) */
+  closeOnBackdrop?: boolean
+  /** 본문을 직접 채우는 모달(계약서처럼)은 기본 패딩을 끈다 */
+  bare?: boolean
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export default function Modal({
+  title,
+  width = "md",
+  closeOnBackdrop = true,
+  bare = false,
+  onClose,
+  children,
+}: ModalProps) {
+  // 모달이 열려 있는 동안 뒤 페이지가 스크롤되지 않게 하고, ESC로 닫는다.
+  useEffect(() => {
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.body.style.overflow = previousOverflow
+      window.removeEventListener("keydown", onKeyDown)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm animate-modal-backdrop p-4"
+      onClick={closeOnBackdrop ? onClose : undefined}
+    >
+      <div
+        className={`bg-white w-full ${WIDTH_CLASS[width]} max-h-[90vh] rounded-2xl shadow-2xl flex flex-col overflow-hidden animate-modal-panel`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-zinc-200 shrink-0">
+          <h2 className="text-lg font-bold">{title}</h2>
+          <button
+            onClick={onClose}
+            aria-label="닫기"
+            className="w-9 h-9 rounded-full flex items-center justify-center text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors cursor-pointer"
+          >
+            <IoClose className="text-xl" />
+          </button>
+        </div>
+
+        <div className={bare ? "flex flex-1 overflow-hidden" : "flex flex-col gap-4 px-6 py-5 overflow-y-auto"}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 모달 하단의 버튼 줄. 취소/확인 배치를 통일한다. */
+export function ModalActions({ children }: { children: React.ReactNode }) {
+  return <div className="flex gap-2 justify-end pt-1">{children}</div>
+}

--- a/src/components/write/PriceCardEditor.tsx
+++ b/src/components/write/PriceCardEditor.tsx
@@ -31,7 +31,7 @@ function SinglePlanEditor({ plan, onChange }: SinglePlanEditorProps) {
       <div className="flex flex-col gap-1">
         <label className="text-sm font-semibold text-zinc-600">플랜 이름</label>
         <input
-          className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main"
+          className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
           placeholder="예) 에어컨 청소 (1회 기준)"
           value={plan.planName}
           onChange={(e) => update({ planName: e.target.value })}
@@ -40,7 +40,7 @@ function SinglePlanEditor({ plan, onChange }: SinglePlanEditorProps) {
 
       <div className="flex flex-col gap-1">
         <label className="text-sm font-semibold text-zinc-600">가격 (최소)</label>
-        <div className="flex items-center border border-zinc-300 rounded-md px-3 py-2 gap-1">
+        <div className="flex items-center gap-1 border border-zinc-300 rounded-lg px-3 py-2.5 transition-colors focus-within:border-main hover:border-zinc-400">
           <input
             className="flex-1 text-sm focus:outline-none"
             placeholder="예) 150000"
@@ -55,7 +55,7 @@ function SinglePlanEditor({ plan, onChange }: SinglePlanEditorProps) {
       <div className="flex flex-col gap-1">
         <label className="text-sm font-semibold text-zinc-600">플랜 설명</label>
         <textarea
-          className="border border-zinc-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-main resize-none"
+          className="border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500 resize-none"
           rows={2}
           placeholder="예) 실외기 실내기 고압세척, 필터 교체/세척"
           value={plan.description}
@@ -78,7 +78,7 @@ function SinglePlanEditor({ plan, onChange }: SinglePlanEditorProps) {
         {plan.items.map((item, i) => (
           <div key={i} className="flex items-center gap-2">
             <input
-              className="flex-1 border border-zinc-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:border-main"
+              className="flex-1 border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
               placeholder="항목명"
               value={item.name}
               onChange={(e) => updateItem(i, { name: e.target.value })}

--- a/src/components/write/WriteInputField.tsx
+++ b/src/components/write/WriteInputField.tsx
@@ -43,13 +43,13 @@ export default function WriteInputField({
 
       {isText ? (
         <textarea
-          className="w-full h-64 border border-zinc-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          className="w-full h-64 border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500 resize-none"
           placeholder={`${name}을 입력해주세요.`}
           value={value}
           onChange={handleChange}
         />
       ) : isInputPrice ? (
-        <div className="flex items-center w-full h-10 border border-zinc-300 rounded-lg px-3 focus-within:ring-2 focus-within:ring-blue-500">
+        <div className="w-full flex items-center gap-1 border border-zinc-300 rounded-lg px-3 py-2.5 transition-colors focus-within:border-main hover:border-zinc-400">
           <input
             type="text"
             className="flex-1 focus:outline-none"
@@ -62,7 +62,7 @@ export default function WriteInputField({
       ) : (
         <input
           type="text"
-          className="w-full h-10 border border-zinc-300 rounded-lg px-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className="w-full border border-zinc-300 rounded-lg px-3 py-2.5 text-sm transition-colors focus:outline-none focus:border-main hover:border-zinc-400 disabled:bg-zinc-100 disabled:text-zinc-500"
           placeholder={`${name}을 입력해주세요.`}
           value={value}
           onChange={handleChange}

--- a/src/components/write/WriteSection.tsx
+++ b/src/components/write/WriteSection.tsx
@@ -33,7 +33,7 @@ export default function WriteSection({
           <select
             value={categoryId}
             onChange={(e) => onCategoryChange(e.target.value ? Number(e.target.value) : "")}
-            className="w-full h-10 border border-zinc-300 rounded-lg pl-3 pr-10 appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full h-10 border border-zinc-300 rounded-lg pl-3 pr-10 text-sm appearance-none transition-colors focus:outline-none focus:border-main hover:border-zinc-400"
           >
             <option value="">카테고리를 선택해주세요</option>
             {categories.map((c) => (


### PR DESCRIPTION
## 작업내용
- [x] 공용 UI 컴포넌트 추가 (`ui/Modal`, `ui/Button`, `ui/Field`)
- [x] 모달 4개를 공용 `Modal`로 통합 (계약서·견적서·서비스선택·계정변경)
      → ESC 닫기, 배경 스크롤 잠금이 전 모달에 일괄 적용
- [x] 버튼 스타일 통일 — radius(`md`/`lg`/`xl` 혼재 → `xl`), hover(`bg-main/90`·`orange-600` 혼재 → `orange-600`), disabled(`opacity-50`/`40` 혼재 → `40`)
- [x] 인풋 스타일 통일 — radius, 패딩, hover 테두리, transition
- [x] 글쓰기 폼의 **파란 포커스 링**(`ring-blue-500`)을 메인 컬러로 교체
- [x] hover 피드백이 없던 클릭 요소 보강 (채팅 첨부 버튼, 썸네일, 헤더 아바타 등)
- [x] 계약 금액이 항상 `0`으로 등록되던 버그 수정 — 계약서에 금액 입력칸 추가
- [x] 채팅 목록 UI 늘어짐 수정 — 패널 폭 고정 + 특수 메시지 미리보기 문구 치환

## 관련 이슈
#

## Jira 기능 링크(선택)

## 확인사항
- [x] 코드스타일이 컨밴션을 따르는지 확인하셨나요?
- [ ] 모든 코드가 정상적으로 동작하는지 확인하셨나요?
