### PR TITLE
fix :: OAuth 토큰 쿼리파라미터 제거 및 세션 쿠키 정리

### DIFF
--- a/src/app/oauth/fail/page.tsx
+++ b/src/app/oauth/fail/page.tsx
@@ -1,25 +1,43 @@
 "use client";
 
+import { Suspense } from 'react';
 import Header from '@/src/components/Header';
 import Footer from '@/src/components/Footer';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+// 서버가 /oauth/fail?code=... 로 넘겨주는 실패 사유
+const FAIL_MESSAGES: Record<string, string> = {
+  OAUTH_PROVIDER_MISMATCH:
+    '해당 이메일은 다른 방식으로 가입된 계정입니다. 기존 가입 수단으로 로그인해 주세요.',
+};
+
+function OAuthFailContent() {
+  const router = useRouter();
+  const code = useSearchParams().get('code');
+  const message = (code && FAIL_MESSAGES[code]) || '다시 시도해주세요';
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-2">
+      <h1 className='text-2xl font-bold'>로그인에 실패했어요 :(</h1>
+      <p className='font-medium text-zinc-400 text-center'>{message}</p>
+      <button
+        onClick={() => router.push('/login/signin')}
+        className='px-4 py-2 bg-main text-white text-sm font-semibold rounded-xl transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer'
+      >
+        다시하기
+      </button>
+    </div>
+  );
+}
 
 export default function page () {
-  const router = useRouter();
   return (
     <div>
       <Header />
-      <div className="flex flex-col items-center justify-center h-full gap-2">
-        <h1 className='text-2xl font-bold'>로그인에 실패했어요 :(</h1>
-        <p className='font-medium text-zinc-400'>다시 시도해주세요</p>
-        <button
-          onClick={() => router.push('/login/signin')}
-          className='px-4 py-2 bg-main text-white text-sm font-semibold rounded-xl transition-colors hover:bg-orange-600 disabled:opacity-40 disabled:hover:bg-main disabled:cursor-not-allowed cursor-pointer'
-        >
-          다시하기
-        </button>
-      </div>
+      <Suspense fallback={null}>
+        <OAuthFailContent />
+      </Suspense>
       <Footer />
     </div>
   );

--- a/src/app/oauth/success/page.tsx
+++ b/src/app/oauth/success/page.tsx
@@ -1,36 +1,37 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/src/store/authStore";
-import { useSearchParams, useRouter } from "next/navigation";
+import { reissueToken } from "@/src/lib/auth";
 
-function OAuthSuccessContent() {
-  const searchParams = useSearchParams();
-  const accessToken = searchParams.get("accessToken");
+export default function Page() {
   const router = useRouter();
   const setToken = useAuthStore((s) => s.setToken);
+  // StrictMode의 이펙트 2회 실행으로 재발급이 두 번 나가지 않게 막는다
+  // (리프레시 토큰이 회전되면 두 번째 호출이 실패한다)
+  const started = useRef(false);
 
   useEffect(() => {
-    if (accessToken) {
-      setToken(accessToken);
-      router.push("/main");
-    } else {
-      router.push("/oauth/fail");
-    }
-  }, [accessToken, router, setToken]);
+    if (started.current) return;
+    started.current = true;
+
+    // 액세스 토큰은 더 이상 쿼리파라미터로 오지 않는다(히스토리·Referer 유출 방지).
+    // 서버가 심은 httpOnly 쿠키로 재발급을 받아 액세스 토큰 문자열을 확보한다.
+    // 이 앱은 모든 API를 Authorization 헤더로 호출하고 username·role도 JWT에서 꺼내 쓰므로
+    // 로그인 확인만으로는 부족하고 토큰 자체가 필요하다.
+    reissueToken()
+      .then((token) => {
+        setToken(token);
+        router.replace("/main");
+      })
+      .catch(() => router.replace("/oauth/fail"));
+  }, [router, setToken]);
 
   return (
     <>
       <h1>로그인에 성공하였습니다!</h1>
       <p>메인페이지로 이동합니다...</p>
     </>
-  );
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={null}>
-      <OAuthSuccessContent />
-    </Suspense>
   );
 }

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
-import { useAuthStore, getTokenRemainingTime } from '@/src/store/authStore'
+import { useAuthStore, getTokenRemainingTime, setSessionCookie } from '@/src/store/authStore'
 import { ensureAccessToken } from '@/src/lib/session'
 
 // 만료 직전에 미리 갱신해 요청 도중 만료되는 것을 막는다
@@ -13,13 +13,11 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const hasSession = useAuthStore((s) => s.hasSession)
   const hydrated = useAuthStore((s) => s.hydrated)
 
-  // 저장된 토큰을 쿠키에 동기화하고, 만료가 임박하면 재발급한다
+  // 세션 마커 쿠키를 동기화하고, 만료가 임박하면 재발급한다
   useEffect(() => {
     if (!hydrated || !hasSession) return
 
-    if (token) {
-      document.cookie = `accessToken=${token}; path=/; SameSite=Lax`
-    }
+    setSessionCookie(true)
 
     const remaining = token ? getTokenRemainingTime(token) : null
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -70,8 +70,6 @@ export async function signup(
       email,
       password,
       ...(phone ? { phone } : {}),
-      role: 'USER',
-      provider: 'AUTH'
     }),
   })
   if (!res.ok) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,12 +3,17 @@ import { NextRequest, NextResponse } from 'next/server'
 const PROTECTED = ['/chat']
 
 export function proxy(req: NextRequest) {
-  const rt = req.cookies.get('accessToken')
+  // 로그인 여부만 본다(값 검증은 하지 않는다 — 실제 인증은 API 서버가 한다).
+  // hasSession: 프론트가 심는 마커 쿠키.
+  // accessToken: 백엔드가 심는 httpOnly 쿠키. 쿠키 도메인이 프론트 오리진까지
+  //   닿는 배포에서는 이쪽만 있을 수도 있어 함께 확인한다.
+  const signedIn =
+    req.cookies.has('hasSession') || req.cookies.has('accessToken')
   const isProtected = PROTECTED.some(
     (p) => req.nextUrl.pathname.startsWith(p)
   )
 
-  if (isProtected && !rt) {
+  if (isProtected && !signedIn) {
     return NextResponse.redirect(
       new URL('/login/signin', req.url)
     )

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -35,13 +35,20 @@ export function getTokenRemainingTime(token: string): number | null {
   return remaining > 0 ? remaining : null
 }
 
-function setAuthCookie(token: string | null) {
+// 미들웨어는 로그인 여부만 확인하므로(proxy.ts) 토큰 값을 쿠키에 복사할 이유가 없다.
+// 예전에는 accessToken 이라는 이름으로 심었는데, 백엔드가 심는 httpOnly 쿠키와 이름이 겹쳐
+// 스코프가 다른 동명 쿠키가 2개씩 쌓였다. 값 없는 마커 쿠키로 분리한다.
+const SESSION_COOKIE = 'hasSession'
+const EXPIRED = 'Thu, 01 Jan 1970 00:00:00 GMT'
+
+export function setSessionCookie(active: boolean) {
   if (typeof document === 'undefined') return
-  if (token) {
-    document.cookie = `accessToken=${token}; path=/; SameSite=Lax`
-  } else {
-    document.cookie = 'accessToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-  }
+  document.cookie = active
+    ? `${SESSION_COOKIE}=1; path=/; SameSite=Lax`
+    : `${SESSION_COOKIE}=; path=/; expires=${EXPIRED}`
+  // 예전 버전이 심어둔 accessToken 쿠키를 걷어낸다.
+  // 백엔드의 httpOnly 쿠키는 JS로 지울 수 없으므로 여기서 지워지는 건 프론트가 만든 것뿐이다.
+  document.cookie = `accessToken=; path=/; expires=${EXPIRED}`
 }
 
 interface AuthStore {
@@ -67,7 +74,7 @@ export const useAuthStore = create<AuthStore>()(
       hydrated: false,
       setHydrated: () => set({ hydrated: true }),
       setToken: (token) => {
-        setAuthCookie(token)
+        setSessionCookie(true)
         set({
           accessToken: token,
           username: decodeJwtUsername(token),
@@ -76,7 +83,7 @@ export const useAuthStore = create<AuthStore>()(
         })
       },
       clear: () => {
-        setAuthCookie(null)
+        setSessionCookie(false)
         set({ accessToken: null, username: null, role: null, hasSession: false })
       },
     }),
@@ -100,9 +107,9 @@ export const useAuthStore = create<AuthStore>()(
       // useAuthStore 를 참조하지 말고 전달받은 state 의 액션을 써야 한다
       onRehydrateStorage: () => (state) => {
         if (!state) return
-        if (state.accessToken && !isTokenExpired(state.accessToken)) {
-          setAuthCookie(state.accessToken)
-        }
+        // 액세스 토큰이 만료됐어도 리프레시 쿠키로 살릴 수 있으므로 세션이 있으면 마커를 유지한다.
+        // (예전에는 만료 시 쿠키를 안 심어서, 재발급 가능한 사용자가 하드 로드 때 로그인으로 튕겼다)
+        if (state.hasSession) setSessionCookie(true)
         state.setHydrated()
       },
     }


### PR DESCRIPTION
## 작업내용
- [x] OAuth 성공 페이지 "accessToken" 쿼리파라미터 파싱 제거 → 토큰 재발급으로 대체
- [x] OAuth 실패 페이지 "?code=" 처리, "OAUTH_PROVIDER_MISMATCH" 메시지 추가
- [x] 회원가입 body에서 "role", "provider" 제거
- [x] 미들웨어용 쿠키를 "hasSession" 마커로 교체

## 관련 이슈
#

## Jira 기능 링크(선택)
//

## 확인사항
- [x] 코드스타일이 컨밴션을 따르는지 확인하셨나요?
- [ ] 모든 코드가 정상적으로 동작하는지 확인하셨나요?