### PR TITLE
131 bug invalid watermark position in contract

### DIFF
--- a/src/components/chat/ContractWizardModal.tsx
+++ b/src/components/chat/ContractWizardModal.tsx
@@ -217,8 +217,6 @@ export default function ContractWizardModal({
     },
   ];
 
-  const showSignatures = step === 2;
-
   return (
     <Modal
       title={`계약서 ${mode === "propose" ? "작성" : "검토 및 서명"}`}
@@ -262,53 +260,51 @@ export default function ContractWizardModal({
             ))}
           </div>
 
-          {showSignatures && (
-            <>
-              <h2 className="relative z-10 text-base font-bold text-center text-contract tracking-widest">
-                {startDate ? formatDate(startDate) : " "}
-              </h2>
-              <div className="relative z-10 grid grid-cols-2 gap-6">
-                <div className="flex flex-col gap-2 border-t-2 border-contract pt-4">
-                  <span className="font-semibold text-sm text-contract">
-                    갑 (의뢰인)
-                  </span>
-                  <span className="text-xs text-zinc-500">
-                    성명(기업명) {clientName}
-                  </span>
-                  {clientSig ? (
-                    <img
-                      src={clientSig}
-                      alt="갑 서명"
-                      className="h-24 object-contain border border-zinc-200 rounded-lg bg-white"
-                    />
-                  ) : (
-                    <div className="h-24 border border-dashed border-zinc-200 rounded-lg bg-zinc-50 flex items-center justify-center text-xs text-zinc-400">
-                      서명 대기 중
-                    </div>
-                  )}
-                </div>
-                <div className="flex flex-col gap-2 border-t-2 border-contract pt-4">
-                  <span className="font-semibold text-sm text-contract">
-                    을 (수행자)
-                  </span>
-                  <span className="text-xs text-zinc-500">
-                    성명(기업명) {professionalName}
-                  </span>
-                  {professionalSig ? (
-                    <img
-                      src={professionalSig}
-                      alt="을 서명"
-                      className="h-24 object-contain border border-zinc-200 rounded-lg bg-white"
-                    />
-                  ) : (
-                    <div className="h-24 border border-dashed border-zinc-200 rounded-lg bg-zinc-50 flex items-center justify-center text-xs text-zinc-400">
-                      서명 대기 중
-                    </div>
-                  )}
-                </div>
+          <>
+            <h2 className="relative z-10 text-base font-bold text-center text-contract tracking-widest">
+              {startDate ? formatDate(startDate) : " "}
+            </h2>
+            <div className="relative z-10 grid grid-cols-2 gap-6">
+              <div className="flex flex-col gap-2 border-t-2 border-contract pt-4">
+                <span className="font-semibold text-sm text-contract">
+                  갑 (의뢰인)
+                </span>
+                <span className="text-xs text-zinc-500">
+                  성명(기업명) {clientName}
+                </span>
+                {clientSig ? (
+                  <img
+                    src={clientSig}
+                    alt="갑 서명"
+                    className="h-24 object-contain border border-zinc-200 rounded-lg bg-white"
+                  />
+                ) : (
+                  <div className="h-24 border border-dashed border-zinc-200 rounded-lg bg-zinc-50 flex items-center justify-center text-xs text-zinc-400">
+                    서명 대기 중
+                  </div>
+                )}
               </div>
-            </>
-          )}
+              <div className="flex flex-col gap-2 border-t-2 border-contract pt-4">
+                <span className="font-semibold text-sm text-contract">
+                  을 (수행자)
+                </span>
+                <span className="text-xs text-zinc-500">
+                  성명(기업명) {professionalName}
+                </span>
+                {professionalSig ? (
+                  <img
+                    src={professionalSig}
+                    alt="을 서명"
+                    className="h-24 object-contain border border-zinc-200 rounded-lg bg-white"
+                  />
+                ) : (
+                  <div className="h-24 border border-dashed border-zinc-200 rounded-lg bg-zinc-50 flex items-center justify-center text-xs text-zinc-400">
+                    서명 대기 중
+                  </div>
+                )}
+              </div>
+            </div>
+          </>
         </div>
       </div>
 

--- a/src/components/chat/ContractWizardModal.tsx
+++ b/src/components/chat/ContractWizardModal.tsx
@@ -133,7 +133,7 @@ export default function ContractWizardModal({
       showMaximumPriceToast();
       return;
     }
-    if (startDate >= endDate) {
+    if (startDate > endDate) {
       showDateToast();
       return;
     }


### PR DESCRIPTION
## 작업내용
- [x] 계약 내용을 입력하는 단계에서 랜더링되는 계약서 아래 부분에 전자서명을 표시해 워터마크가 전자서명을 입력하는 단계와 같은 위치에 표시되도록 수정했습니다.
- [x] 계약 시작일과 계약 종료일이 같은 경우 '계약 시작일은 종료일보다 앞서야 해요.' 토스트 메시지가 출력되지 않도록 했습니다. - 당일 완료되는 용역도 존재하기에 수정

## 관련 이슈
#131 

## 첨부사진
### [Before]
<img width="1800" height="1169" alt="Image" src="https://github.com/user-attachments/assets/4e7bf4d1-b8ce-4eb4-bb6a-8f834994efbe" />
<img width="1800" height="1169" alt="Image" src="https://github.com/user-attachments/assets/94a68b7d-e8eb-469d-9198-f4c987c687c6" />
두 단계별로 워터마크의 위치가 다름

### [After]
<img width="1800" height="1169" alt="Screenshot 2026-09-12 at 4 17 13 PM" src="https://github.com/user-attachments/assets/e936f6d4-5ba1-49ba-983f-64284be23736" />
<img width="1800" height="1169" alt="Screenshot 2026-09-12 at 4 17 13 PM" src="https://github.com/user-attachments/assets/9b913d08-c020-4675-8c48-f560d5f4f16b" />
- 두 단계별 워터마크의 위치 일치
- 용역이 당일 종료되는 경우 허용

## 확인사항
- [ ] 코드스타일이 컨밴션을 따르는지 확인하셨나요?
- [x] 모든 코드가 정상적으로 동작하는지 확인하셨나요?

With Codex ChatGPT 5.6 Luna